### PR TITLE
Fix/start game flow update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,24 +10,24 @@ GOARCH=amd64
 
 # Build the default binary
 build:
- go build -o $(BINARY_NAME) $(MAIN)
+	go build -o $(BINARY_NAME) $(MAIN)
 
 # Build with inline button binary name
 build-inline:
- go build -o tg-game-bot-inline-button $(MAIN)
+	go build -o tg-game-bot-inline-button $(MAIN)
 
 # Build with markup button binary name
 build-markup:
- go build -o tg-game-bot-markup-button $(MAIN)
+	go build -o tg-game-bot-markup-button $(MAIN)
 
 # Cross-compilation build (for Linux)
 build-linux:
- GOOS=$(GOOS) GOARCH=$(GOARCH) go build -o $(BINARY_NAME)_$(GOOS)_$(GOARCH) $(MAIN)
+	GOOS=$(GOOS) GOARCH=$(GOARCH) go build -o $(BINARY_NAME)_$(GOOS)_$(GOARCH) $(MAIN)
 
 # Remove generated binaries
 clean:
- rm -f $(BINARY_NAME) $(BINARY_NAME)_*
+	rm -f $(BINARY_NAME) $(BINARY_NAME)_*
 
 # Run the bot without building
 run:
- go run $(MAIN)
+	go run $(MAIN)

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -428,6 +428,14 @@ func StartGameHandlerFoo(bot *telebot.Bot) func(c telebot.Context) error {
 			return nil
 		}
 
+		// Delete message with button "Start game" after click
+		go func ()  {
+			err := bot.Delete(c.Message())
+			if err != nil {
+			utils.Logger.Errorf("Failed to delete message with button: %v", err)
+			}
+		}()
+
 		game, err := storage_db.GetGameByChatId(chat.ID)
 		if err != nil {
 			utils.Logger.Errorf("Error getting game by chat ID(%d): %v", chat.ID, err)

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -240,7 +240,9 @@ func CheckAdminBotHandler(bot *telebot.Bot) func(c telebot.Context) error {
 			{joinBtn},
 		}
 
-		bot.Send(chat, "Хочеш #приєднатися до гри? 🏠 Тицяй кнопку", inline)
+		msgJoin, _ := bot.Send(chat, "Хочеш приєднатися до гри? 🏠 Тицяй кнопку", inline)
+		joinMsgId := msgJoin.ID
+		storage_db.UpdateMsgJoinID(game.ID, joinMsgId)
 		
 		time.Sleep(5 * time.Second)
 
@@ -702,11 +704,27 @@ func OnAnswerTaskBtnHandler(bot *telebot.Bot) func(c telebot.Context) error {
 			return nil
 		}
 		if !userIsInGame {
-			msg, err := bot.Send(chat, fmt.Sprintf("🎉 @%s, ти ще не в грі! Натисни кнопку на початку гри #приєднатися щоб приєднатися і повертайся до завдання.", user.Username))
+			msgJoinID, err := storage_db.GetMsgJoinID(game.ID)
 			if err != nil {
-				utils.Logger.Errorf("Error sending message to user %s: %v", user.Username, err)
+				utils.Logger.Errorf("Error getting join message ID for game %d: %v", game.ID, err)
 				return nil
 			}
+			chatID := utils.CleanChatID(chat.ID)
+
+			msgJoinLink := fmt.Sprintf("https://t.me/c/%s/%d", chatID, msgJoinID)
+
+			msg, err := bot.Send(chat, fmt.Sprintf(
+				`🎉 @%s, ти ще не в грі! Натисни <a href="%s">приєднатися до гри</a>, щоб приєднатися і повертайся до завдання.`,
+				user.Username, msgJoinLink),
+				&telebot.SendOptions{
+					ParseMode: telebot.ModeHTML,
+				})
+
+			if err != nil {
+				utils.Logger.Errorf("Error sending join message  with link to user %s: %v", user.Username, err)
+				return nil
+			}
+
 			time.Sleep(30 * time.Second)
 			err = bot.Delete(msg)
 			if err != nil {
@@ -783,11 +801,27 @@ func OnSkipTaskBtnHandler(bot *telebot.Bot) func(c telebot.Context) error {
 			return nil
 		}
 		if !userIsInGame {
-			msg, err := bot.Send(chat, fmt.Sprintf("🎉 @%s, ти ще не в грі! Натисни кнопку #приєднатися на початку щоб приєднатися і повертайся до завдання.", user.Username))
+			msgJoinID, err := storage_db.GetMsgJoinID(game.ID)
 			if err != nil {
-				utils.Logger.Errorf("Error sending message to user %s: %v", user.Username, err)
+				utils.Logger.Errorf("Error getting join message ID for game %d: %v", game.ID, err)
 				return nil
 			}
+			chatID := utils.CleanChatID(chat.ID)
+
+			msgJoinLink := fmt.Sprintf("https://t.me/c/%s/%d", chatID, msgJoinID)
+
+			msg, err := bot.Send(chat, fmt.Sprintf(
+				`🎉 @%s, ти ще не в грі! Натисни <a href="%s">приєднатися до гри</a>, щоб приєднатися і повертайся до завдання.`,
+				user.Username, msgJoinLink),
+				&telebot.SendOptions{
+					ParseMode: telebot.ModeHTML,
+				})
+
+			if err != nil {
+				utils.Logger.Errorf("Error sending join message  with link to user %s: %v", user.Username, err)
+				return nil
+			}
+
 			time.Sleep(30 * time.Second)
 			err = bot.Delete(msg)
 			if err != nil {

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -809,7 +809,15 @@ func OnSkipTaskBtnHandler(bot *telebot.Bot) func(c telebot.Context) error {
 		case status.AlreadySkipped:
 			bot.Send(chat, fmt.Sprintf("⏭️ @%s, ти вже пропустила це завдання.", user.Username))
 		case status.SkipLimitReached:
-			bot.Send(chat, fmt.Sprintf("🚫 @%s, ти вже пропустила максимальну дозволену кількість завдань.", user.Username))
+			msg, _ := bot.Send(chat, fmt.Sprintf("🚫 @%s, ти вже пропустила максимальну дозволену кількість завдань.", user.Username))
+			
+			// Delete the message after 5 seconds
+			time.AfterFunc(5 * time.Second, func() {
+				err = bot.Delete(msg)
+				if err != nil {
+					utils.Logger.Errorf("Error deleting skip limit reached message for user %s: %v", user.Username, err)
+				}
+			})
 		default:
 			bot.Send(chat, fmt.Sprintf("✅ @%s, завдання пропущено! У тебе залишилось %d пропуск(ів).", user.Username, status.RemainingSkips-1))
 		}

--- a/models/models.go
+++ b/models/models.go
@@ -14,6 +14,7 @@ type Game struct {
 	ID int
 	Name string
 	GameChatID int64
+	MsgJointID int // ID of the message with the "Join" button
     //InviteLink string
 	CurrentTaskID int
     TotalPlayers int // max 5

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -73,3 +73,8 @@ func LoadJoinMessagges(path string) ([]string, error) {
 	}
 	return messages, nil
 }
+
+func CleanChatID(chatID int64) string {
+	idStr := strconv.FormatInt(chatID, 10)
+	return strings.TrimPrefix(idStr, "-100")
+}


### PR DESCRIPTION
## What's Changed

- Bot now sends a "Start Game" button when added to a group.
- Once an admin presses the "Start Game" button, the message and button are deleted immediately.
- Redundant logic for repeated pressing of the button was commented out since it's now unreachable.
- Removed the message notifying players that they've reached the maximum number of allowed skips.
- When a player tries to answer a task without having joined the game, the bot now sends a direct link to the original "Join Game" message instead of a plain reminder.

## Motivation

Improves the start-game flow UX and removes redundant or potentially annoying messages.
